### PR TITLE
✨Add a Check, if the CallActivity contains a CalledElement

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   configs: {
     recommended: {
       rules: {
+        'process-engine/callactivity-target-required': 'error',
         'process-engine/no-more-than-one-participant': 'error',
         'process-engine/start-event-required': 'error',
         'process-engine/end-event-required': 'error',

--- a/src/callactivity-target-required.ts
+++ b/src/callactivity-target-required.ts
@@ -1,0 +1,27 @@
+import {ICallActivityElement, IDefinitions, IModdleElement} from '@process-engine/bpmn-elements_contracts';
+
+import * as lintUtils from 'bpmnlint-utils';
+import {BpmnLintReporter} from './contracts/bpmn-lint-reporter';
+
+/**
+ * Rule that checks, if a CallActivity contains a target.
+ */
+module.exports = (): any => {
+
+  function check(node: IModdleElement, reporter: BpmnLintReporter): void {
+    const currentNodeIsCallActivity: boolean = lintUtils.is(node, 'bpmn:CallActivity');
+
+    if (currentNodeIsCallActivity) {
+      const currentCallActivity: ICallActivityElement = node as ICallActivityElement;
+      const calledElementNotAssigned: boolean = currentCallActivity.calledElement === null;
+
+      if (calledElementNotAssigned) {
+        reporter.report(currentCallActivity.id, 'No CalledElement assigned');
+      }
+    }
+  }
+
+  return {
+    check: check,
+  };
+};

--- a/src/callactivity-target-required.ts
+++ b/src/callactivity-target-required.ts
@@ -17,7 +17,7 @@ module.exports = (): any => {
                                                 || currentCallActivity.calledElement === null;
 
       if (calledElementNotAssigned) {
-        reporter.report(currentCallActivity.id, 'No CalledElement assigned');
+        reporter.report(currentCallActivity.id, 'No called element assigned');
       }
     }
   }

--- a/src/callactivity-target-required.ts
+++ b/src/callactivity-target-required.ts
@@ -13,7 +13,8 @@ module.exports = (): any => {
 
     if (currentNodeIsCallActivity) {
       const currentCallActivity: ICallActivityElement = node as ICallActivityElement;
-      const calledElementNotAssigned: boolean = currentCallActivity.calledElement === null;
+      const calledElementNotAssigned: boolean = currentCallActivity.calledElement === undefined
+                                                || currentCallActivity.calledElement === null;
 
       if (calledElementNotAssigned) {
         reporter.report(currentCallActivity.id, 'No CalledElement assigned');


### PR DESCRIPTION
**Changes:**

1. Adds a check, if a CallActivity contains a `CalledElement`. 


**Issues:**

Related: https://github.com/process-engine/bpmn-studio/issues/1426

PR: #?

## How can others test the changes?

* Link against bpmn studio
* Add a CallActivity with no CalledElement set
* See, that the linter complains about that. 

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).
