### PR TITLE
✨ Add rule for gateways with mixed split- and join- purpose

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
         'process-engine/no-complex-gateway': 'error',
         'process-engine/no-inclusive-gateway': 'error',
         'process-engine/no-event-based-gateway': 'error',
+        'process-engine/no-mixed-gateways': 'error',
         'process-engine/collaboration-required': 'error',
         'process-engine/participant-required': 'error',
         'process-engine/no-undefined-error-event': 'error',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpmnlint-plugin-process-engine",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "The plugin used to describe and develop Process Engine specific rules for the bpmn linter.",
   "main": "index.js",
   "scripts": {

--- a/src/no-mixed-gateways.ts
+++ b/src/no-mixed-gateways.ts
@@ -1,0 +1,36 @@
+import {IModdleElement} from '@process-engine/bpmn-elements_contracts';
+import * as lintUtils from 'bpmnlint-utils';
+
+import {BpmnLintReporter} from './contracts/bpmn-lint-reporter';
+
+/**
+ * Rule that reports if a gateway has a mixed Split- and Join- purpose.
+ */
+module.exports = (): any => {
+
+  function check(node: IModdleElement, reporter: BpmnLintReporter): void {
+
+    const nodeIsNotAGateway: boolean = !(lintUtils.is(node, 'bpmn:ComplexGateway')
+                                      || lintUtils.is(node, 'bpmn:EventBasedGateway')
+                                      || lintUtils.is(node, 'bpmn:ExclusiveGateway')
+                                      || lintUtils.is(node, 'bpmn:InclusiveGateway')
+                                      || lintUtils.is(node, 'bpmn:ParallelGateway'));
+
+    if (nodeIsNotAGateway) {
+      return;
+    }
+
+    const nodeHasMultipleIncomingSequenceFlows: boolean = node.incoming.length > 1;
+    const nodeHasMultipleOutgoingSequenceFlows: boolean = node.outgoing.length > 1;
+
+    const gatewayIsMixed: boolean = nodeHasMultipleIncomingSequenceFlows && nodeHasMultipleOutgoingSequenceFlows;
+
+    if (gatewayIsMixed) {
+      reporter.report(node.id, 'Gateways with mixed Split- and Join- purpose are not allowed!');
+    }
+  }
+
+  return {
+    check: check,
+  };
+};


### PR DESCRIPTION
**Changes:**

Add a rule for checking if a gateway has a mixed Split- and Join- purpose.
This type of gateway is prohibited by the ProcessEngine.

**Issues:**

Part of https://github.com/process-engine/bpmn-studio/issues/1429

PR: #10

## How can others test the changes?

Try modelling a ProcessModel that has a gateway with multiple incoming **and** outgoing SequenceFlows. 
This should trigger the rule.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).
