### PR TITLE
✨ Add no undefined message task

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ module.exports = {
         'process-engine/no-undefined-error-event': 'error',
         'process-engine/no-undefined-timer-event': 'error',
         'process-engine/no-undefined-signal-event': 'error',
-        'process-engine/no-undefined-message-event': 'error'
+        'process-engine/no-undefined-message-event': 'error',
+        'process-engine/no-undefined-message-task': 'error',
       }
     },
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpmnlint-plugin-process-engine",
-  "version": "1.7.2-alpha.3",
+  "version": "1.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/no-undefined-message-task.ts
+++ b/src/no-undefined-message-task.ts
@@ -1,0 +1,31 @@
+import { IMessageTask, IModdleElement } from '@process-engine/bpmn-elements_contracts';
+import * as lintUtils from 'bpmnlint-utils';
+
+import {BpmnLintReporter} from './contracts/bpmn-lint-reporter';
+
+/**
+ * Rule that reports if a process contains an undefined Send- or ReceiveTask.
+ */
+module.exports = (): any => {
+
+  function check(node: IModdleElement, reporter: BpmnLintReporter): void {
+
+    const nodeIsMessageTask: boolean = lintUtils.is(node, 'bpmn:SendTask')
+                                    || lintUtils.is(node, 'bpmn:ReceiveTask');
+
+    if (nodeIsMessageTask) {
+      const eventElement: IMessageTask = node as IMessageTask;
+
+      const noMessageDefined = eventElement.messageRef == null;
+
+      if (noMessageDefined) {
+        reporter.report(node.id, 'The Message is not defined.');
+      }
+    }
+
+  }
+
+  return {
+    check: check,
+  };
+};


### PR DESCRIPTION
## Changes

1. Fügt eine Regel hinzu, die überprüft ob Send- oder ReceiveTasks eine Message definiert haben.

![Bildschirmfoto 2020-11-05 um 09 54 40](https://user-images.githubusercontent.com/17065920/98220195-3e6a5c00-1f4e-11eb-84f1-e1715d86e830.png)


## Issues

PR: #19 

## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
